### PR TITLE
Fix method name in LifeExpectancyShould

### DIFF
--- a/api/MWL/Tests/MWL.Services.UnitTests/LifeExpectancyShould.cs
+++ b/api/MWL/Tests/MWL.Services.UnitTests/LifeExpectancyShould.cs
@@ -36,7 +36,7 @@ namespace MWL.Services.UnitTests
 
         [Fact]
         [Trait("Category", "Unit")]
-        public void HaveEstimatedEstimatedWeekendsLeft1512()
+        public void HaveEstimatedWeekendsLeft1512()
         {
             // Arrange - done in constructor 
 


### PR DESCRIPTION
## Summary
- rename `HaveEstimatedEstimatedWeekendsLeft1512` to `HaveEstimatedWeekendsLeft1512`

## Testing
- `dotnet test api/MWL/MWL.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc71264c832bb19a6c89e46be87f