### PR TITLE
Fix comment spelling in WeekendsLeftService

### DIFF
--- a/api/MWL/MWL.Services/Implementation/WeekendsLeftService.cs
+++ b/api/MWL/MWL.Services/Implementation/WeekendsLeftService.cs
@@ -36,7 +36,7 @@ namespace MWL.Services.Implementation
                 return weekendsLeftResponse;
             }
 
-            // County Code Validation
+            // Country Code Validation
             if (!_countriesService.GetCountryData().ContainsKey(weekendsLeftRequest.Country.ToUpper()))
             {
                 weekendsLeftResponse.Errors = new[] {"Country Code is not valid"};


### PR DESCRIPTION
## Summary
- fix typo in WeekendsLeftService comment

## Testing
- `dotnet test api/MWL/MWL.sln --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc821f44832bbef7e146d62432e2