### PR TITLE
Convert age validation test to theory

### DIFF
--- a/api/MWL/Tests/MWL.Services.UnitTests/WeekendsLeftShould.cs
+++ b/api/MWL/Tests/MWL.Services.UnitTests/WeekendsLeftShould.cs
@@ -67,22 +67,25 @@ namespace MWL.Services.UnitTests
             _output.WriteLine("HaveEstimatedAgeOfDeathInRange was tested");
         }
 
-        [Fact]
+        [Theory]
         [Trait("Category", "Unit")]
-        public async Task NotAllowNegativeAgesAsync()
+        [InlineData(-5)]
+        [InlineData(0)]
+        [InlineData(121)]
+        public async Task NotAllowNegativeAgesAsync(int age)
         {
-            // Arrange - done in constructor 
+            // Arrange - done in constructor
 
             var weekendsLeftRequest = new WeekendsLeftRequest
             {
-                Age = -5
+                Age = age
             };
 
             // Act
             var weekendsLeftResponse = await weekendsLeftService.GetWeekendsLeftAsync(weekendsLeftRequest);
 
             // Assert
-            Assert.Contains("'Age' must be between 1 and 120. You entered -5.", weekendsLeftResponse.Errors);
+            Assert.Contains($"'Age' must be between 1 and 120. You entered {age}.", weekendsLeftResponse.Errors);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- convert `NotAllowNegativeAgesAsync` test into a parameterized theory
- validate the error message for each invalid age

## Testing
- `dotnet test api/MWL/Tests/MWL.Services.UnitTests/MWL.Services.UnitTests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc8daf00832ba6ab73273a6fda32