### PR TITLE
Replace deprecated versioning packages

### DIFF
--- a/api/MWL/MWL.API/MWL.API.csproj
+++ b/api/MWL/MWL.API/MWL.API.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- replace `Microsoft.AspNetCore.Mvc.Versioning` packages with the `Asp.Versioning.Mvc` equivalents

## Testing
- `dotnet test api/MWL/MWL.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450325b128832b88dd1abf7e02c014