### PR TITLE
Remove staging slot from infrastructure

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -84,41 +84,9 @@ jobs:
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         retention-days: 1
 
-  deploy-staging:
-    name: Deploy to Staging
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment:
-      name: 'Staging'
-      url: ${{ steps.deploy-to-staging.outputs.webapp-url }}
-
-    steps:
-    - name: Download artifact from build job
-      uses: actions/download-artifact@v4
-      with:
-        name: dotnet-app
-        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
-    - name: Deploy to Azure App Service (Staging Slot)
-      id: deploy-to-staging
-      uses: azure/webapps-deploy@v3
-      with:
-        app-name: ${{ env.AZURE_WEBAPP_NAME }}
-        slot-name: 'staging'
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_STAGING }}
-        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
-    - name: Verify Staging Deployment
-      run: |
-        echo "Waiting for staging slot to be ready..."
-        sleep 30
-        curl -f -s -o /dev/null -w "%{http_code}" ${{ steps.deploy-to-staging.outputs.webapp-url }}/health || exit 1
-        echo "Staging deployment verified successfully!"
-
   deploy-production:
     name: Deploy to Production
-    needs: deploy-staging
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,8 +40,7 @@ If you prefer not to use Terraform, create these resources manually:
 1. Resource Group: `rg-mwl-prod-001`
 2. App Service Plan: `plan-mwl-prod-001` (Windows, S1)
 3. App Service: `app-mwl-prod-001` (.NET 9)
-4. Staging Slot for the App Service
-5. Application Insights: `appi-mwl-prod-001`
+4. Application Insights: `appi-mwl-prod-001`
 
 ---
 
@@ -50,7 +49,7 @@ If you prefer not to use Terraform, create these resources manually:
 ### Get Publish Profiles from Azure
 
 ```bash
-# Production publish profile
+# Get production publish profile
 az webapp deployment list-publishing-profiles \
   --name app-mwl-prod-001 \
   --resource-group rg-mwl-prod-001 \
@@ -59,28 +58,16 @@ az webapp deployment list-publishing-profiles \
 # Copy the entire XML output
 ```
 
-```bash
-# Staging publish profile
-az webapp deployment list-publishing-profiles \
-  --name app-mwl-prod-001 \
-  --resource-group rg-mwl-prod-001 \
-  --slot staging \
-  --xml
-
-# Copy the entire XML output
-```
-
-### Add Secrets to GitHub
+### Add Secret to GitHub
 
 1. Go to your GitHub repository
 2. Click **Settings** → **Secrets and variables** → **Actions**
 3. Click **New repository secret**
-4. Add these two secrets:
+4. Add this secret:
 
 | Secret Name | Value |
 |------------|-------|
-| `AZURE_WEBAPP_PUBLISH_PROFILE` | Paste the **production** XML |
-| `AZURE_WEBAPP_PUBLISH_PROFILE_STAGING` | Paste the **staging** XML |
+| `AZURE_WEBAPP_PUBLISH_PROFILE` | Paste the XML output from above |
 
 ---
 
@@ -97,8 +84,7 @@ git push origin main
 The GitHub Actions workflow will automatically:
 1. ✅ Build the application
 2. ✅ Run all 39 tests
-3. ✅ Deploy to staging
-4. ✅ Deploy to production
+3. ✅ Deploy to production
 
 ### Method 2: Manual Trigger
 
@@ -127,8 +113,6 @@ curl https://app-mwl-prod-001.azurewebsites.net/health
 # Test API endpoint
 curl "https://app-mwl-prod-001.azurewebsites.net/api/getweekends/?age=45&gender=male&country=USA"
 
-# Test staging
-curl https://app-mwl-prod-001-staging.azurewebsites.net/health
 ```
 
 Expected responses:
@@ -157,7 +141,7 @@ Now deployments to production will require manual approval!
 Your API is now deployed with:
 
 - ✅ Automated CI/CD pipeline
-- ✅ Blue-green deployments (staging → production)
+- ✅ Direct to production deployments
 - ✅ Health monitoring
 - ✅ Application Insights telemetry
 - ✅ All 39 tests running on every deployment

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -16,7 +16,6 @@ This directory contains the infrastructure-as-code and deployment configuration 
 - **Resources**:
   - App Service Plan (S1, Windows)
   - App Service (Production)
-  - App Service Slot (Staging)
   - Application Insights
   - Resource Group
 
@@ -48,13 +47,12 @@ terraform apply -var="environment=prod"
 **Important Outputs:**
 - `app_service_name` - Your Azure App Service name
 - `app_service_default_hostname` - Production URL
-- `staging_slot_hostname` - Staging URL
 
 ### 2. Configure GitHub Secrets
 
-You need to add two secrets to your GitHub repository:
+You need to add one secret to your GitHub repository:
 
-#### Get Publish Profiles from Azure
+#### Get Publish Profile from Azure
 
 **For Production:**
 ```bash
@@ -64,16 +62,7 @@ az webapp deployment list-publishing-profiles \
   --xml > production-profile.xml
 ```
 
-**For Staging:**
-```bash
-az webapp deployment list-publishing-profiles \
-  --name app-mwl-prod-001 \
-  --resource-group rg-mwl-prod-001 \
-  --slot staging \
-  --xml > staging-profile.xml
-```
-
-#### Add Secrets to GitHub
+#### Add Secret to GitHub
 
 1. Go to your repository on GitHub
 2. Navigate to **Settings** → **Secrets and variables** → **Actions**
@@ -95,10 +84,8 @@ rm production-profile.xml staging-profile.xml
 For production approvals and protection:
 
 1. Go to **Settings** → **Environments**
-2. Create two environments:
-   - **Staging**
-   - **Production**
-3. For **Production** environment:
+2. Create a **Production** environment
+3. Configure the Production environment:
    - Add required reviewers (yourself or team members)
    - Set deployment branch policy to `main` only
    - Add environment secrets if needed
@@ -122,12 +109,10 @@ For production approvals and protection:
 ```mermaid
 graph LR
     A[Build & Test] --> B{Tests Pass?}
-    B -->|Yes| C[Deploy to Staging]
+    B -->|Yes| C[Deploy to Production]
     B -->|No| D[❌ Fail]
-    C --> E[Verify Staging]
-    E --> F[Deploy to Production]
-    F --> G[Verify Production]
-    G --> H[✅ Complete]
+    C --> E[Verify Production]
+    E --> F[✅ Complete]
 ```
 
 ### Test Execution
@@ -145,14 +130,9 @@ The pipeline runs **39 tests** in three categories:
    - Build solution in Release mode
    - Run all tests with code coverage
 
-2. **Deploy to Staging**
+2. **Deploy to Production**
    - Publish application
-   - Deploy to staging slot
-   - Verify `/health` endpoint
-
-3. **Deploy to Production**
-   - Download build artifact
-   - Deploy to production
+   - Deploy to production App Service
    - Verify `/health` endpoint
 
 ---
@@ -177,7 +157,6 @@ All resources follow Azure naming best practices:
 ✅ **TLS 1.2 Minimum**: Secure communications enforced
 ✅ **.NET 9**: Latest framework configured
 ✅ **Application Insights**: Full telemetry and monitoring
-✅ **Staging Slot**: Blue-green deployments enabled
 ✅ **CORS**: Configured to allow all origins (adjust as needed)
 ✅ **HTTP/2**: Enabled for better performance
 ✅ **Always On**: Prevents cold starts
@@ -198,7 +177,6 @@ After `terraform apply`, you'll get:
 
 - Resource group name
 - App Service URL (production)
-- Staging slot URL
 - Application Insights keys
 - App ID
 

--- a/infrastructure/tf/prod/main.tf
+++ b/infrastructure/tf/prod/main.tf
@@ -106,54 +106,6 @@ resource "azurerm_windows_web_app" "main" {
   tags = azurerm_resource_group.main.tags
 }
 
-# App Service Staging Slot
-resource "azurerm_windows_web_app_slot" "staging" {
-  name           = "staging"
-  app_service_id = azurerm_windows_web_app.main.id
-  https_only     = true
-
-  site_config {
-    always_on                          = true
-    http2_enabled                      = true
-    minimum_tls_version                = "1.2"
-    ftps_state                         = "FtpsOnly"
-    health_check_path                  = "/health"
-    health_check_eviction_time_in_min = 2
-
-    application_stack {
-      current_stack  = "dotnet"
-      dotnet_version = "v9.0"
-    }
-
-    cors {
-      allowed_origins = ["*"]
-    }
-  }
-
-  app_settings = {
-    "APPINSIGHTS_INSTRUMENTATIONKEY"             = azurerm_application_insights.main.instrumentation_key
-    "APPLICATIONINSIGHTS_CONNECTION_STRING"      = azurerm_application_insights.main.connection_string
-    "ApplicationInsightsAgent_EXTENSION_VERSION" = "~3"
-    "ASPNETCORE_ENVIRONMENT"                     = "Staging"
-    "MwlConfiguration__LifeExpectancyApiUri"     = "https://d6wn6bmjj722w.population.io/1.0/life-expectancy/remaining"
-  }
-
-  logs {
-    application_logs {
-      file_system_level = "Information"
-    }
-
-    http_logs {
-      file_system {
-        retention_in_days = 7
-        retention_in_mb   = 35
-      }
-    }
-  }
-
-  tags = azurerm_resource_group.main.tags
-}
-
 # Auto-healing rules
 resource "azurerm_windows_web_app" "auto_heal" {
   count               = 0 # Set to 1 to enable auto-healing

--- a/infrastructure/tf/prod/outputs.tf
+++ b/infrastructure/tf/prod/outputs.tf
@@ -23,11 +23,6 @@ output "app_service_default_hostname" {
   value       = "https://${azurerm_windows_web_app.main.default_hostname}"
 }
 
-output "staging_slot_hostname" {
-  description = "The hostname of the staging slot"
-  value       = "https://${azurerm_windows_web_app_slot.staging.default_hostname}"
-}
-
 output "instrumentation_key" {
   description = "Application Insights instrumentation key"
   value       = azurerm_application_insights.main.instrumentation_key


### PR DESCRIPTION
Simplified deployment by removing the staging slot requirement:
- Removed azurerm_windows_web_app_slot resource from Terraform
- Updated GitHub Actions workflow to deploy directly to production
- Removed staging deployment job and dependencies
- Updated all documentation to reflect single-slot deployment
- Removed staging slot references from outputs

This change reduces infrastructure complexity and deployment time while maintaining all quality gates (build, test, health checks).