### PR TITLE
Fix CORS headers missing on cached API responses

### DIFF
--- a/api/MWL/MWL.API/Controllers/WeekendsLeftController.cs
+++ b/api/MWL/MWL.API/Controllers/WeekendsLeftController.cs
@@ -40,7 +40,7 @@ namespace MWL.API.Controllers
         [HttpGet]
         [ApiVersion("1.0")]
         [Route("getweekends/")]
-        [ResponseCache(Duration = 3600, VaryByQueryKeys = new[] { "age", "gender", "country" })]
+        [ResponseCache(Duration = 3600, VaryByQueryKeys = new[] { "age", "gender", "country" }, VaryByHeader = "Origin")]
         [ProducesResponseType(typeof(WeekendsLeftResponse), 200)]
         [ProducesResponseType(typeof(ProblemDetails), 400)]
         [ProducesResponseType(typeof(ProblemDetails), 503)]

--- a/api/MWL/MWL.API/Startup.cs
+++ b/api/MWL/MWL.API/Startup.cs
@@ -130,9 +130,6 @@ namespace MWL.API
             // Enable response compression
             app.UseResponseCompression();
 
-            // Enable response caching (after compression, before routing)
-            app.UseResponseCaching();
-
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
@@ -146,6 +143,9 @@ namespace MWL.API
 
             // Enable CORS
             app.UseCors();
+
+            // Enable response caching (after CORS so cached responses include CORS headers)
+            app.UseResponseCaching();
 
             app.UseAuthorization();
 


### PR DESCRIPTION
- Add VaryByHeader = "Origin" to ResponseCache so cached responses are stored per-origin with correct CORS headers
- Move UseResponseCaching() after UseCors() in middleware pipeline so CORS headers are included before responses are cached